### PR TITLE
Fix the number of configurations in hyperband

### DIFF
--- a/Stanford-D3M-Full/executors/HyperbandExecutor.py
+++ b/Stanford-D3M-Full/executors/HyperbandExecutor.py
@@ -143,7 +143,7 @@ class HyperbandExecutor(executors.Executor.Executor):
         s_max = int(math.floor(math.log(R, eta)))
         # B = (s_max + 1) * R
         for s in range(0, s_max + 1):
-            n = math.ceil(int((s_max + 1) / (s + 1)) * eta ** s)
+            n = math.ceil((s_max + 1) / (s + 1) * eta ** s)
             r = R * eta ** (-s)
             bracket = []
             for i in range(0, s + 1):


### PR DESCRIPTION
The number of configuration in the hyperband executor has an additional rounding operation that deviates from the original paper formula.

The whole explanation is available in this blog post: https://medium.com/data-from-the-trenches/a-slightly-better-budget-allocation-for-hyperband-bbd45af14481